### PR TITLE
Fix broken API query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ To uninstall, paste the following command into a terminal window:
 Updates
 --------------
 
+2/22/2019
+
+Updated to support latest version of the vendor lookup API. The API was updated which broke everything. It's all functional again.
+
 11/29/2017
 
 Added support for dropped leading zeros in MAC address octets, such as found with the `arp -a` command on OS X.

--- a/mac_format
+++ b/mac_format
@@ -102,12 +102,12 @@ end
 
 # OUI Lookup
 def lookup_vendor(mac)
-  api_response = open("http://mac2vendor.com/api/v3/mac/#{mac}").read
+  api_response = open("https://mac2vendor.com/api/v4/mac/#{mac}").read
   mac_info = JSON.parse(api_response)
-  if mac_info['error']
+  if mac_info['success'] == false
     "Unknown Vendor"
   else
-    mac_info['data']['vendor']
+    mac_info['payload'][0]['vendor']
   end
 end
 


### PR DESCRIPTION
Vendor lookup API was changed, old version appears to be deprecated. Method handling lookup has been updated to reflect this. 